### PR TITLE
chore: use GH_AUTOMATION_PAT instead of GH_PAT (#104

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       ARM_USE_OIDC: true
       TF_VAR_azure_resource_group_name: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
-      GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+      GITHUB_TOKEN: ${{ secrets.GH_AUTOMATION_PAT }}
       GITHUB_OWNER: kedacore
 
     steps:

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -20,7 +20,7 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       ARM_USE_OIDC: true
       TF_VAR_azure_resource_group_name: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
-      GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+      GITHUB_TOKEN: ${{ secrets.GH_AUTOMATION_PAT }}
       GITHUB_OWNER: kedacore
 
     steps:


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO)

Related to #
