### PR TITLE
test: Rename AKS test cluster

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -57,7 +57,7 @@ module "azure_aks_pr" {
   source              = "./modules/azure/aks"
   resource_group_name = var.azure_resource_group_name
   kubernetes_version  = "1.25"
-  cluster_name        = pr_cluster_name
+  cluster_name        = local.pr_cluster_name
 
   azure_monitor_workspace_id   = module.azure_monitor_stack.azure_monitor_workspace_id
   azure_monitor_workspace_name = module.azure_monitor_stack.azure_monitor_workspace_name

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,8 +4,8 @@ locals {
     Environment = "e2e"
   }
 
-  pr_cluster_name   = "keda-pr-run"
-  main_cluster_name = "keda-nightly-run-3"
+  pr_cluster_name   = "keda-e2e-cluster-pr"
+  main_cluster_name = "keda-e2e-cluster-nightly"
 }
 
 // ====== GCP ======
@@ -57,7 +57,7 @@ module "azure_aks_pr" {
   source              = "./modules/azure/aks"
   resource_group_name = var.azure_resource_group_name
   kubernetes_version  = "1.25"
-  cluster_name        = "keda-pr-run"
+  cluster_name        = pr_cluster_name
 
   azure_monitor_workspace_id   = module.azure_monitor_stack.azure_monitor_workspace_id
   azure_monitor_workspace_name = module.azure_monitor_stack.azure_monitor_workspace_name
@@ -78,7 +78,7 @@ module "azure_aks_nightly" {
   source              = "./modules/azure/aks"
   resource_group_name = var.azure_resource_group_name
   kubernetes_version  = "1.25"
-  cluster_name        = "keda-nightly-run-3"
+  cluster_name        = main_cluster_name
 
   azure_monitor_workspace_id   = module.azure_monitor_stack.azure_monitor_workspace_id
   azure_monitor_workspace_name = module.azure_monitor_stack.azure_monitor_workspace_name

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -78,7 +78,7 @@ module "azure_aks_nightly" {
   source              = "./modules/azure/aks"
   resource_group_name = var.azure_resource_group_name
   kubernetes_version  = "1.25"
-  cluster_name        = main_cluster_name
+  cluster_name        = local.main_cluster_name
 
   azure_monitor_workspace_id   = module.azure_monitor_stack.azure_monitor_workspace_id
   azure_monitor_workspace_name = module.azure_monitor_stack.azure_monitor_workspace_name


### PR DESCRIPTION
As we are going to a new Azure subscription, now might be the perfect time to rename and align naming conventions.

In this case, I'd like to standardize the AKS cluster name.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Related to https://github.com/kedacore/testing-infrastructure/issues/107
