### PR TITLE
fix: downgrade aks because 1.26 has issues on e2e tests

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -57,7 +57,7 @@ module "azuread_applications" {
 module "azure_aks_pr" {
   source              = "./modules/azure/aks"
   resource_group_name = var.azure_resource_group_name
-  kubernetes_version  = "1.26"
+  kubernetes_version  = "1.25"
   cluster_name        = local.pr_cluster_name
   unique_project_name = var.unique_project_name
 
@@ -79,7 +79,7 @@ module "azure_aks_pr" {
 module "azure_aks_nightly" {
   source              = "./modules/azure/aks"
   resource_group_name = var.azure_resource_group_name
-  kubernetes_version  = "1.26"
+  kubernetes_version  = "1.25"
   cluster_name        = local.main_cluster_name
   unique_project_name = var.unique_project_name
 


### PR DESCRIPTION


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Related to #
