### PR TITLE
chore: Add TF_AZURE_EVENTHUB_NAMESPACE secret

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -252,6 +252,12 @@ module "github_secrets" {
   repository = var.repository
   secrets = [
     {
+      name  = "TF_AZURE_EVENTHUB_NAMESPACE"
+      value = module.azure_event_hub_namespace.namespace_name
+    },
+    # Remove TF_AZURE_EVENTHBUS_MANAGEMENT_CONNECTION_STRING after 
+    # https://github.com/kedacore/keda/pull/5471 is merged
+    {
       name  = "TF_AZURE_EVENTHBUS_MANAGEMENT_CONNECTION_STRING"
       value = module.azure_event_hub_namespace.manage_connection_string
     },

--- a/terraform/modules/azure/event-hub-namespace/outputs.tf
+++ b/terraform/modules/azure/event-hub-namespace/outputs.tf
@@ -1,3 +1,7 @@
 output "manage_connection_string" {
   value = azurerm_eventhub_namespace_authorization_rule.manage_connection.primary_connection_string
 }
+
+output "namespace_name" {
+  value = local.event_hub_name
+}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Related to #
