### PR TITLE
test: Upgrade AKS cluster to Kubernetes v1.30

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -81,7 +81,7 @@ module "azuread_applications" {
 module "azure_aks_pr" {
   source              = "./modules/azure/aks"
   resource_group_name = var.azure_resource_group_name
-  kubernetes_version  = "1.29"
+  kubernetes_version  = "1.30"
   cluster_name        = local.pr_cluster_name
   unique_project_name = var.unique_project_name
 
@@ -103,7 +103,7 @@ module "azure_aks_pr" {
 module "azure_aks_nightly" {
   source              = "./modules/azure/aks"
   resource_group_name = var.azure_resource_group_name
-  kubernetes_version  = "1.29"
+  kubernetes_version  = "1.30"
   cluster_name        = local.main_cluster_name
   unique_project_name = var.unique_project_name
 


### PR DESCRIPTION
Upgrade AKS cluster to Kubernetes v1.30.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Related to https://github.com/kedacore/keda/issues/5828
